### PR TITLE
Implement convex slicing MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+output_frames/
+*.stl

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # 3D-Slicing
-3D model slicing software that uses convex slicing instead of planar slicing
+
+3D model slicing software that uses convex slicing instead of planar slicing.
+
+## Features
+
+- Computes a steady-state convex meniscus curve from printing parameters.
+- Centers and aligns STL models before slicing.
+- Performs voxel-based convex slicing using a configurable pitch (default 0.05 mm).
+- Exports incremental exposure frames as 8-bit BMP images and optional metadata.
+
+## Installation
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the slicer by pointing it at an STL model and an output directory:
+
+```bash
+python -m slicer.cli path/to/model.stl output_frames/ --metadata output_frames/summary.json
+```
+
+By default the slicer uses the MVP parameters:
+
+- Print head diameter: 5.42 mm
+- Rim starting height: 0.75 mm
+- Contact angle: 45 °
+- Surface tension: 73
+- Density (rho): 1000 kg/m³
+- Gravity: 9.81 m/s²
+- Bézier coefficients: k1 = 0.25, k2 = 0.75
+- Pitch: 0.05 mm
+
+These can be overridden using command-line options (see `python -m slicer.cli --help`).
+
+The generated metadata file contains the normalized meniscus profile, applied model
+translation, and the apex height used for each frame.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+trimesh
+Pillow
+pytest
+scipy

--- a/slicer/__init__.py
+++ b/slicer/__init__.py
@@ -1,0 +1,15 @@
+"""Convex slicing MVP package."""
+
+from .cli import main
+from .meniscus import MeniscusParameters, SteadyMeniscus
+from .model import ModelPreparer
+from .slicing import ConvexSlicer, SliceResult
+
+__all__ = [
+    "main",
+    "MeniscusParameters",
+    "SteadyMeniscus",
+    "ModelPreparer",
+    "ConvexSlicer",
+    "SliceResult",
+]

--- a/slicer/cli.py
+++ b/slicer/cli.py
@@ -1,0 +1,99 @@
+"""Command line interface for the convex slicer."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .meniscus import MeniscusParameters
+from .model import ModelPreparer
+from .slicing import ConvexSlicer
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convex slicing MVP")
+    parser.add_argument("stl", type=Path, help="Path to the STL model")
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Directory that will contain generated BMP frames",
+    )
+    parser.add_argument("--pitch", type=float, default=0.05, help="Vertical pitch in mm")
+    parser.add_argument(
+        "--print-head-diameter",
+        type=float,
+        default=5.42,
+        help="Print head diameter in mm",
+    )
+    parser.add_argument(
+        "--rim-height",
+        type=float,
+        default=0.75,
+        help="Rim starting height in mm",
+    )
+    parser.add_argument(
+        "--contact-angle",
+        type=float,
+        default=45.0,
+        help="Contact angle in degrees",
+    )
+    parser.add_argument(
+        "--surface-tension",
+        type=float,
+        default=73.0,
+        help="Surface tension (mN/m)",
+    )
+    parser.add_argument("--density", type=float, default=1000.0, help="Density rho (kg/m^3)")
+    parser.add_argument("--gravity", type=float, default=9.81, help="Gravity (m/s^2)")
+    parser.add_argument("--bezier-k1", type=float, default=0.25)
+    parser.add_argument("--bezier-k2", type=float, default=0.75)
+    parser.add_argument(
+        "--metadata",
+        type=Path,
+        default=None,
+        help="Optional path for a metadata JSON summary",
+    )
+    return parser
+
+
+def main(argv: Any | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    params = MeniscusParameters(
+        print_head_diameter=args.print_head_diameter,
+        rim_height=args.rim_height,
+        contact_angle_deg=args.contact_angle,
+        surface_tension=args.surface_tension,
+        density=args.density,
+        gravity=args.gravity,
+        bezier_k1=args.bezier_k1,
+        bezier_k2=args.bezier_k2,
+    )
+
+    preparer = ModelPreparer()
+    prepared = preparer.load(args.stl)
+    slicer = ConvexSlicer(prepared, params, pitch=args.pitch)
+    results = slicer.slice(args.output)
+
+    if args.metadata:
+        summary: Dict[str, Any] = {
+            "input": str(args.stl.resolve()),
+            "output": str(args.output.resolve()),
+            "pitch_mm": args.pitch,
+            "frame_count": len(results),
+            "apex_heights_mm": [r.apex_height for r in results],
+            "translation_mm": prepared.translation.tolist(),
+            "model_height_mm": prepared.height,
+            "meniscus_profile": slicer.meniscus_points().tolist(),
+            "capillary_length_m": params.capillary_length,
+        }
+        args.metadata.parent.mkdir(parents=True, exist_ok=True)
+        args.metadata.write_text(json.dumps(summary, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slicer/meniscus.py
+++ b/slicer/meniscus.py
@@ -1,0 +1,110 @@
+"""Meniscus profile calculation for convex slicing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Tuple
+
+import numpy as np
+
+
+@dataclass
+class MeniscusParameters:
+    """Physical parameters describing the steady-state meniscus."""
+
+    print_head_diameter: float  # mm
+    rim_height: float  # mm
+    contact_angle_deg: float  # degrees
+    surface_tension: float  # mN/m or equivalent units (used for diagnostics)
+    density: float  # kg/m^3
+    gravity: float  # m/s^2
+    bezier_k1: float
+    bezier_k2: float
+
+    @property
+    def radius(self) -> float:
+        return self.print_head_diameter / 2.0
+
+    @property
+    def contact_angle_rad(self) -> float:
+        return math.radians(self.contact_angle_deg)
+
+    @property
+    def capillary_length(self) -> float:
+        """Capillary length derived from the supplied physical properties."""
+        # Convert surface tension from mN/m to N/m if provided in that unit.
+        gamma = self.surface_tension / 1000.0
+        return math.sqrt(gamma / (self.density * self.gravity))
+
+
+class SteadyMeniscus:
+    """Represents the steady-state meniscus profile using a cubic Bézier curve."""
+
+    def __init__(self, params: MeniscusParameters, samples: int = 256) -> None:
+        self.params = params
+        self.samples = samples
+        self._sample_profile()
+
+    def _control_points(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        p = self.params
+        radius = p.radius
+        rim_height = p.rim_height
+
+        p0 = np.array([0.0, 0.0])
+        p1 = np.array([radius * p.bezier_k1, 0.0])
+
+        slope = -math.tan(p.contact_angle_rad)
+        r3 = radius
+        z3 = -rim_height
+        r2 = radius * p.bezier_k2
+        z2 = z3 - slope * (r3 - r2)
+        p2 = np.array([r2, z2])
+        p3 = np.array([r3, z3])
+
+        return p0, p1, p2, p3
+
+    def _sample_profile(self) -> None:
+        p0, p1, p2, p3 = self._control_points()
+        t_values = np.linspace(0.0, 1.0, self.samples)
+        r_samples = self._cubic_bezier(t_values, p0[0], p1[0], p2[0], p3[0])
+        z_samples = self._cubic_bezier(t_values, p0[1], p1[1], p2[1], p3[1])
+
+        # Ensure monotonicity for interpolation.
+        order = np.argsort(r_samples)
+        self._r_samples = r_samples[order]
+        self._z_samples = z_samples[order]
+
+    @staticmethod
+    def _cubic_bezier(t: np.ndarray, p0: float, p1: float, p2: float, p3: float) -> np.ndarray:
+        inv_t = 1.0 - t
+        return (
+            (inv_t ** 3) * p0
+            + 3.0 * (inv_t ** 2) * t * p1
+            + 3.0 * inv_t * (t ** 2) * p2
+            + (t ** 3) * p3
+        )
+
+    def height_for_radius(self, radius: np.ndarray) -> np.ndarray:
+        """Return the vertical offset of the meniscus for the supplied radius.
+
+        The returned height is relative to the apex of the meniscus. The apex
+        height itself is defined elsewhere by the slicing routine.
+        """
+
+        radius = np.asarray(radius)
+        z = np.interp(radius, self._r_samples, self._z_samples, left=self._z_samples[0], right=self._z_samples[-1])
+        outside = radius > self.params.radius
+        if np.any(outside):
+            z = np.array(z, copy=True)
+            z[outside] = np.nan
+        return z
+
+    def apex_adjustment(self) -> float:
+        """Return the offset between the meniscus rim and apex heights."""
+        # The rim is located at radius = print head radius.
+        rim_height = np.interp(self.params.radius, self._r_samples, self._z_samples)
+        return -rim_height
+
+    def as_points(self) -> np.ndarray:
+        """Return sampled (r, z) pairs describing the profile."""
+        return np.column_stack((self._r_samples, self._z_samples))

--- a/slicer/model.py
+++ b/slicer/model.py
@@ -1,0 +1,46 @@
+"""Utilities for loading and preparing 3D models for slicing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import trimesh
+
+
+@dataclass
+class PreparedModel:
+    mesh: trimesh.Trimesh
+    translation: np.ndarray
+    bounds: Tuple[np.ndarray, np.ndarray]
+
+    @property
+    def height(self) -> float:
+        return float(self.bounds[1][2] - self.bounds[0][2])
+
+
+class ModelPreparer:
+    """Load, center, and align meshes for convex slicing."""
+
+    def __init__(self, ensure_watertight: bool = True) -> None:
+        self.ensure_watertight = ensure_watertight
+
+    def load(self, path: Path) -> PreparedModel:
+        mesh = trimesh.load_mesh(path, process=True)
+        if not isinstance(mesh, trimesh.Trimesh):
+            raise ValueError("Expected an STL mesh containing a single solid model")
+
+        if self.ensure_watertight and not mesh.is_watertight:
+            mesh = mesh.fill_holes()
+
+        mesh = mesh.copy()
+        bounds = mesh.bounds
+        center_x = (bounds[0][0] + bounds[1][0]) / 2.0
+        center_y = (bounds[0][1] + bounds[1][1]) / 2.0
+        min_z = bounds[0][2]
+        translation = np.array([-center_x, -center_y, -min_z])
+        mesh.apply_translation(translation)
+        centered_bounds = mesh.bounds
+
+        return PreparedModel(mesh=mesh, translation=translation, bounds=centered_bounds)

--- a/slicer/slicing.py
+++ b/slicer/slicing.py
@@ -1,0 +1,181 @@
+"""Convex slicing engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+import numpy as np
+from PIL import Image
+
+from .meniscus import MeniscusParameters, SteadyMeniscus
+from .model import PreparedModel
+
+
+@dataclass
+class SliceResult:
+    frame_index: int
+    apex_height: float
+    image_path: Path
+
+
+class ConvexSlicer:
+    """Perform convex slicing on an STL model."""
+
+    def __init__(
+        self,
+        model: PreparedModel,
+        meniscus_params: MeniscusParameters,
+        pitch: float,
+    ) -> None:
+        self.model = model
+        self.pitch = pitch
+        self.meniscus = SteadyMeniscus(meniscus_params)
+        self._validate_model()
+        self._prepare_sampling_grid()
+        self._voxelize_model()
+
+    def _validate_model(self) -> None:
+        radius = self.meniscus.params.radius
+        max_radius = np.max(np.linalg.norm(self.model.mesh.vertices[:, :2], axis=1))
+        if max_radius > radius:
+            raise ValueError(
+                "Model exceeds print head radius. Increase the print head size or scale the model."
+            )
+
+    def _prepare_sampling_grid(self) -> None:
+        radius = self.meniscus.params.radius
+        pitch = self.pitch
+        diameter = radius * 2.0
+        steps = int(np.ceil(diameter / pitch))
+        x_coords = -radius + (np.arange(steps) + 0.5) * pitch
+        y_coords = -radius + (np.arange(steps) + 0.5) * pitch
+
+        self.x_coords = x_coords
+        self.y_coords = y_coords
+        self.radius_grid = np.sqrt(x_coords[:, None] ** 2 + y_coords[None, :] ** 2)
+        self.profile_grid = self.meniscus.height_for_radius(self.radius_grid)
+        self.profile_grid = np.where(
+            np.isfinite(self.profile_grid), self.profile_grid, -np.inf
+        )
+
+        height = self.model.height
+        z_steps = max(int(np.ceil(height / pitch)), 1)
+        self.z_coords = (np.arange(z_steps) + 0.5) * pitch
+
+    def _voxelize_model(self) -> None:
+        mesh = self.model.mesh
+        nx = len(self.x_coords)
+        ny = len(self.y_coords)
+        nz = len(self.z_coords)
+
+        triangles = mesh.triangles
+        tri_xy = triangles[:, :, :2]
+        tri_z = triangles[:, :, 2]
+
+        # Precompute barycentric denominators for efficiency.
+        v0 = tri_xy[:, 1] - tri_xy[:, 0]
+        v1 = tri_xy[:, 2] - tri_xy[:, 0]
+        denom = v0[:, 0] * v1[:, 1] - v0[:, 1] * v1[:, 0]
+
+        columns: List[List[float]] = [[] for _ in range(nx * ny)]
+        tol = 1e-9
+        first_x = self.x_coords[0]
+        first_y = self.y_coords[0]
+        pitch = self.pitch
+
+        for tri_idx, tri in enumerate(tri_xy):
+            area = abs(denom[tri_idx]) * 0.5
+            if area < tol:
+                continue
+
+            min_xy = tri.min(axis=0)
+            max_xy = tri.max(axis=0)
+
+            ix_start = max(0, int(np.floor((min_xy[0] - first_x) / pitch)))
+            ix_end = min(nx - 1, int(np.ceil((max_xy[0] - first_x) / pitch)))
+            iy_start = max(0, int(np.floor((min_xy[1] - first_y) / pitch)))
+            iy_end = min(ny - 1, int(np.ceil((max_xy[1] - first_y) / pitch)))
+
+            if ix_start > ix_end or iy_start > iy_end:
+                continue
+
+            tri_z_vals = tri_z[tri_idx]
+            denom_value = denom[tri_idx]
+
+            for ix in range(ix_start, ix_end + 1):
+                x0 = self.x_coords[ix]
+                if x0 < min_xy[0] - pitch or x0 > max_xy[0] + pitch:
+                    continue
+                for iy in range(iy_start, iy_end + 1):
+                    y0 = self.y_coords[iy]
+                    if y0 < min_xy[1] - pitch or y0 > max_xy[1] + pitch:
+                        continue
+
+                    dx = x0 - tri_xy[tri_idx, 0, 0]
+                    dy = y0 - tri_xy[tri_idx, 0, 1]
+                    u = (v1[tri_idx, 1] * dx - v1[tri_idx, 0] * dy) / denom_value
+                    v = (-v0[tri_idx, 1] * dx + v0[tri_idx, 0] * dy) / denom_value
+                    w = 1.0 - u - v
+                    if min(u, v, w) < -1e-6 or max(u, v, w) > 1.0 + 1e-6:
+                        continue
+
+                    z = u * tri_z_vals[1] + v * tri_z_vals[2] + w * tri_z_vals[0]
+                    columns[ix * ny + iy].append(z)
+
+        occupancy = np.zeros((nx, ny, nz), dtype=bool)
+        z_centers = self.z_coords
+
+        for idx, intersections in enumerate(columns):
+            if not intersections:
+                continue
+            zs = np.array(sorted(intersections))
+            unique = []
+            for value in zs:
+                if not unique or abs(value - unique[-1]) > 1e-5:
+                    unique.append(value)
+            if len(unique) < 2:
+                continue
+
+            ix = idx // ny
+            iy = idx % ny
+
+            for start in range(0, len(unique) - 1, 2):
+                lower = unique[start]
+                upper = unique[start + 1]
+                if upper < lower:
+                    lower, upper = upper, lower
+                mask = (z_centers >= lower - self.pitch / 2) & (z_centers <= upper + self.pitch / 2)
+                occupancy[ix, iy, mask] = True
+
+        self.occupancy = occupancy
+
+    def _apex_heights(self) -> Sequence[float]:
+        height = self.model.height
+        steps = int(np.ceil(height / self.pitch))
+        return [self.meniscus.params.rim_height + self.pitch * (i + 1) for i in range(steps)]
+
+    def slice(self, output_dir: Path) -> List[SliceResult]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        apex_heights = list(self._apex_heights())
+        results: List[SliceResult] = []
+        cumulative_mask = np.zeros(self.profile_grid.shape, dtype=bool)
+
+        for index, apex in enumerate(apex_heights):
+            surface = apex + self.profile_grid
+            z_mask = self.z_coords[None, None, :] <= surface[:, :, None]
+            exposure = np.any(self.occupancy & z_mask, axis=2)
+            incremental = exposure & ~cumulative_mask
+            cumulative_mask |= exposure
+
+            image_array = np.flipud(incremental.T.astype(np.uint8) * 255)
+            image = Image.fromarray(image_array, mode="L")
+            filename = output_dir / f"frame_{index:04d}.bmp"
+            image.save(filename)
+
+            results.append(SliceResult(frame_index=index, apex_height=apex, image_path=filename))
+
+        return results
+
+    def meniscus_points(self) -> np.ndarray:
+        return self.meniscus.as_points()

--- a/tests/test_meniscus.py
+++ b/tests/test_meniscus.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from slicer.meniscus import MeniscusParameters, SteadyMeniscus
+
+
+def test_meniscus_profile_is_monotonic():
+    params = MeniscusParameters(
+        print_head_diameter=5.42,
+        rim_height=0.75,
+        contact_angle_deg=45.0,
+        surface_tension=73.0,
+        density=1000.0,
+        gravity=9.81,
+        bezier_k1=0.25,
+        bezier_k2=0.75,
+    )
+    meniscus = SteadyMeniscus(params, samples=32)
+    points = meniscus.as_points()
+    radii = points[:, 0]
+    heights = points[:, 1]
+    assert np.all(np.diff(radii) >= -1e-6)
+    assert heights[0] > heights[-1]


### PR DESCRIPTION
## Summary
- implement a convex slicing package that models the steady meniscus, voxelizes models, and generates incremental BMP frames
- add a command line entry point, documentation, and project requirements for running the slicer
- introduce a basic meniscus unit test and pytest configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca748893448327b021c98bf845c167