### PR TITLE
Implement convex slicing MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # 3D-Slicing
-3D model slicing software that uses convex slicing instead of planar slicing
+
+3D model slicing software that uses convex slicing instead of planar slicing.
+
+## Features
+
+- Loads STL meshes, recenters them in the print volume and aligns the base to the
+  configured rim height.
+- Computes a steady-phase convex meniscus using the supplied physics parameters
+  (surface tension, density, gravity, print-head geometry, Bézier control
+  coefficients).
+- Voxelises the mesh and generates a sequence of BMP frames that follow the
+  curved meniscus for each pitch increment.
+- Writes metadata describing the slicing run (pitch, voxel size, meniscus
+  control points and scaling).
+
+## Usage
+
+Install the dependencies and run the slicer from the repository root:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python -m convex_slicer.cli path/to/model.stl output_directory --pitch 0.05
+```
+
+Optional arguments:
+
+- `--voxel-size`: specify a custom voxel size (defaults to the pitch).
+- `--params`: path to a JSON file overriding the default material and geometry
+  parameters.
+
+Each frame is written as an 8-bit monochrome BMP named `frame_XXXX.bmp`. The
+`slicing/metadata.json` file captures the parameters used for the run.
+
+## Default parameters
+
+The default values (matching the MVP requirements) are:
+
+- Print head diameter: 5.42 mm
+- Rim starting height: 0.75 mm
+- Contact angle: 45°
+- Surface tension: 73
+- Density: 1000
+- Gravity: 9.81
+- Bézier k1: 0.25
+- Bézier k2: 0.75
+
+The slicer uses these to build a cubic Bézier approximation of the steady
+meniscus profile (center low, rim high) and applies the same profile for every
+layer as it marches through the height of the model using the configured pitch.

--- a/convex_slicer/__init__.py
+++ b/convex_slicer/__init__.py
@@ -1,0 +1,12 @@
+"""Convex slicing package."""
+
+from .parameters import PrintingParameters
+from .steady_state import SteadyPhaseProfile, compute_steady_phase_profile
+from .slicer import ConvexSlicer
+
+__all__ = [
+    "PrintingParameters",
+    "SteadyPhaseProfile",
+    "compute_steady_phase_profile",
+    "ConvexSlicer",
+]

--- a/convex_slicer/cli.py
+++ b/convex_slicer/cli.py
@@ -1,0 +1,72 @@
+"""Command line interface for the convex slicer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .parameters import PrintingParameters
+from .slicer import ConvexSlicer
+
+
+DEFAULT_PARAMS = PrintingParameters(
+    print_head_diameter=5.42,
+    rim_start_height=0.75,
+    contact_angle_deg=45.0,
+    surface_tension=73.0,
+    density=1000.0,
+    gravity=9.81,
+    bezier_k1=0.25,
+    bezier_k2=0.75,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convex slicer MVP")
+    parser.add_argument("stl", type=Path, help="Path to the input STL model")
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Directory where the slice frames will be written",
+    )
+    parser.add_argument(
+        "--pitch",
+        type=float,
+        default=0.05,
+        help="Vertical pitch between slices in millimetres (default: 0.05)",
+    )
+    parser.add_argument(
+        "--voxel-size",
+        type=float,
+        default=None,
+        help="Override the voxel size used for rasterisation (default: pitch)",
+    )
+    parser.add_argument(
+        "--params",
+        type=Path,
+        default=None,
+        help="Optional JSON file overriding the default printing parameters",
+    )
+    return parser
+
+
+def load_parameters(path: Path | None) -> PrintingParameters:
+    if path is None:
+        return DEFAULT_PARAMS
+    with Path(path).open("r", encoding="utf-8") as fp:
+        data = json.load(fp)
+    return PrintingParameters(**data)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    params = load_parameters(args.params)
+    slicer = ConvexSlicer(params, pitch=args.pitch, voxel_size=args.voxel_size)
+    slicer.slice(args.stl, args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/convex_slicer/parameters.py
+++ b/convex_slicer/parameters.py
@@ -1,0 +1,25 @@
+"""Data structures for convex slicing parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrintingParameters:
+    """Collection of physics and geometry parameters for the slicer."""
+
+    print_head_diameter: float
+    rim_start_height: float
+    contact_angle_deg: float
+    surface_tension: float
+    density: float
+    gravity: float
+    bezier_k1: float
+    bezier_k2: float
+
+    @property
+    def print_head_radius(self) -> float:
+        """Return half the print-head diameter."""
+
+        return self.print_head_diameter / 2.0

--- a/convex_slicer/slicer.py
+++ b/convex_slicer/slicer.py
@@ -1,0 +1,157 @@
+"""Core slicing logic."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+import trimesh
+
+from .parameters import PrintingParameters
+from .steady_state import SteadyPhaseProfile, compute_steady_phase_profile
+
+
+@dataclass
+class SlicingResult:
+    """Container for slicing outputs."""
+
+    output_directory: Path
+    num_frames: int
+    pitch: float
+    voxel_size: float
+
+
+class ConvexSlicer:
+    """Generate convex slices for an STL model."""
+
+    def __init__(
+        self,
+        params: PrintingParameters,
+        *,
+        pitch: float = 0.05,
+        voxel_size: Optional[float] = None,
+        profile: Optional[SteadyPhaseProfile] = None,
+    ) -> None:
+        self.params = params
+        self.pitch = float(pitch)
+        self.voxel_size = float(voxel_size) if voxel_size is not None else float(pitch)
+        self.profile = profile or compute_steady_phase_profile(params)
+
+    def slice(self, stl_path: Path, output_dir: Path) -> SlicingResult:
+        """Slice the provided STL model and write image frames."""
+
+        mesh = self._load_mesh(stl_path)
+        mesh = self._prepare_mesh(mesh)
+        voxel_grid = mesh.voxelized(self.voxel_size).fill()
+        occupancy = voxel_grid.matrix.astype(bool)
+        transform = voxel_grid.transform
+        x_coords, y_coords, z_coords = _axis_coordinates(transform, occupancy.shape)
+
+        xx, yy = np.meshgrid(x_coords, y_coords, indexing="ij", sparse=False)
+        radii = np.sqrt(xx**2 + yy**2)
+        surface_offsets = self.profile.height(radii)
+
+        model_height = mesh.bounds[1, 2] - self.params.rim_start_height
+        scale = 1.0
+        if self.profile.max_height >= model_height and self.profile.max_height > 0:
+            scale = 0.8 * model_height / self.profile.max_height
+            surface_offsets *= scale
+
+        base_surface = self.params.rim_start_height + surface_offsets
+
+        num_frames = max(int(math.ceil(model_height / self.pitch)), 1)
+        z_coords = np.asarray(z_coords)
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        metadata = {
+            "pitch": self.pitch,
+            "voxel_size": self.voxel_size,
+            "num_frames": num_frames,
+            "rim_start_height": self.params.rim_start_height,
+            "print_head_radius": self.params.print_head_radius,
+            "meniscus_scale": scale,
+            "control_points": self.profile.control_points.tolist(),
+        }
+
+        for frame in range(num_frames):
+            lower = base_surface + frame * self.pitch
+            upper = lower + self.pitch
+            slice_mask = _slice_mask(occupancy, z_coords, lower, upper)
+            _save_mask(output_dir, frame, slice_mask)
+
+        with (output_dir / "metadata.json").open("w", encoding="utf-8") as fp:
+            json.dump(metadata, fp, indent=2)
+
+        return SlicingResult(
+            output_directory=output_dir,
+            num_frames=num_frames,
+            pitch=self.pitch,
+            voxel_size=self.voxel_size,
+        )
+
+    def _load_mesh(self, stl_path: Path) -> trimesh.Trimesh:
+        mesh = trimesh.load_mesh(stl_path)
+        if isinstance(mesh, trimesh.Scene):
+            mesh = mesh.dump().sum()
+        if not isinstance(mesh, trimesh.Trimesh):
+            raise TypeError("Unsupported mesh type: expected a triangular mesh")
+        return mesh
+
+    def _prepare_mesh(self, mesh: trimesh.Trimesh) -> trimesh.Trimesh:
+        mesh = mesh.copy()
+        bounds = mesh.bounds
+        center_xy = (bounds[0, :2] + bounds[1, :2]) / 2.0
+        translation = np.array([
+            -center_xy[0],
+            -center_xy[1],
+            self.params.rim_start_height - bounds[0, 2],
+        ])
+        mesh.apply_translation(translation)
+        return mesh
+
+
+def _axis_coordinates(transform: np.ndarray, shape: Iterable[int]) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute coordinate arrays for the voxel grid axes."""
+
+    shape = tuple(int(v) for v in shape)
+    origin = transform @ np.array([0.0, 0.0, 0.0, 1.0])
+    axis_vectors = (
+        transform @ np.array([1.0, 0.0, 0.0, 0.0]),
+        transform @ np.array([0.0, 1.0, 0.0, 0.0]),
+        transform @ np.array([0.0, 0.0, 1.0, 0.0]),
+    )
+    x_coords = origin[0] + axis_vectors[0][0] * np.arange(shape[0])
+    y_coords = origin[1] + axis_vectors[1][1] * np.arange(shape[1])
+    z_coords = origin[2] + axis_vectors[2][2] * np.arange(shape[2])
+    return x_coords, y_coords, z_coords
+
+
+def _slice_mask(
+    occupancy: np.ndarray,
+    z_coords: np.ndarray,
+    lower: np.ndarray,
+    upper: np.ndarray,
+) -> np.ndarray:
+    """Compute a binary mask for a slice between ``lower`` and ``upper`` surfaces."""
+
+    z_grid = z_coords[np.newaxis, np.newaxis, :]
+    within = (z_grid >= lower[..., np.newaxis]) & (z_grid < upper[..., np.newaxis])
+    hits = occupancy & within
+    mask = np.any(hits, axis=2)
+    return mask
+
+
+def _save_mask(output_dir: Path, index: int, mask: np.ndarray) -> None:
+    """Write the mask as an 8-bit BMP image."""
+
+    from PIL import Image
+
+    array = (mask.astype(np.uint8) * 255).T[::-1, :]
+    image = Image.fromarray(array)
+    image.save(output_dir / f"frame_{index:04d}.bmp")

--- a/convex_slicer/steady_state.py
+++ b/convex_slicer/steady_state.py
@@ -1,0 +1,116 @@
+"""Computation of the steady-phase meniscus profile."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+from .parameters import PrintingParameters
+
+
+def _bezier_point(t: np.ndarray, control_points: np.ndarray) -> np.ndarray:
+    """Evaluate a cubic Bézier curve at ``t``.
+
+    Parameters
+    ----------
+    t:
+        Array of parameters in ``[0, 1]``.
+    control_points:
+        Array of shape ``(4, 2)`` representing ``(radius, height)`` pairs.
+    """
+
+    t = np.atleast_1d(t)
+    cp = control_points
+    # Bernstein basis
+    b0 = (1 - t) ** 3
+    b1 = 3 * (1 - t) ** 2 * t
+    b2 = 3 * (1 - t) * t**2
+    b3 = t**3
+    points = (
+        b0[..., None] * cp[0]
+        + b1[..., None] * cp[1]
+        + b2[..., None] * cp[2]
+        + b3[..., None] * cp[3]
+    )
+    return points
+
+
+@dataclass
+class SteadyPhaseProfile:
+    """Axisymmetric steady-phase profile for the convex slicing surface."""
+
+    control_points: np.ndarray
+    radius: float
+    rim_height: float
+
+    def height(self, r: Iterable[float]) -> np.ndarray:
+        """Return the meniscus height offset relative to the center.
+
+        Values outside the print-head radius are clamped to ``0``.
+        """
+
+        r = np.asarray(r, dtype=float)
+        r_clamped = np.clip(r, 0.0, self.radius)
+        t = np.zeros_like(r_clamped)
+        nonzero = self.radius > 0
+        if nonzero:
+            t = r_clamped / self.radius
+        points = _bezier_point(t, self.control_points)
+        heights = points[..., 1]
+        heights = np.where(r <= self.radius, heights, 0.0)
+        return heights
+
+    @property
+    def max_height(self) -> float:
+        """Return the maximum height offset."""
+
+        return float(self.control_points[-1, 1])
+
+
+def compute_steady_phase_profile(
+    params: PrintingParameters,
+    *,
+    peak_scale: float = 0.6,
+    capillary_fraction: float = 0.1,
+) -> SteadyPhaseProfile:
+    """Approximate the steady-phase meniscus using a cubic Bézier curve.
+
+    The approximation is inspired by the steady-state model in Dynamic
+    Interface Printing. The curve is axisymmetric and parameterised by the
+    radial distance from the print-head centre.
+
+    Parameters
+    ----------
+    params:
+        Printing and material parameters.
+    peak_scale:
+        Relative scaling used for the peak height estimation when capillary
+        effects are small.
+    capillary_fraction:
+        Fraction of the capillary length used when estimating the peak height.
+    """
+
+    radius = params.print_head_radius
+    angle = np.deg2rad(params.contact_angle_deg)
+    capillary_length_m = np.sqrt(params.surface_tension / (params.density * params.gravity))
+    capillary_length_mm = capillary_length_m * 1000.0
+
+    peak_guess = min(radius * peak_scale, capillary_length_mm * capillary_fraction)
+    peak_guess = max(peak_guess, 1e-6)
+
+    rim_offset = max(peak_guess - np.tan(angle) * radius * (1.0 - params.bezier_k2), 0.0)
+    peak_height = rim_offset + np.tan(angle) * radius * (1.0 - params.bezier_k2)
+
+    control_points = np.array(
+        [
+            [0.0, 0.0],
+            [radius * params.bezier_k1, 0.0],
+            [radius * params.bezier_k2, rim_offset],
+            [radius, peak_height],
+        ],
+        dtype=float,
+    )
+
+    return SteadyPhaseProfile(control_points=control_points, radius=radius, rim_height=params.rim_start_height)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+trimesh
+Pillow
+scipy
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from convex_slicer.parameters import PrintingParameters
+from convex_slicer.steady_state import compute_steady_phase_profile
+
+
+def test_profile_monotonic_increasing():
+    params = PrintingParameters(
+        print_head_diameter=5.42,
+        rim_start_height=0.75,
+        contact_angle_deg=45.0,
+        surface_tension=73.0,
+        density=1000.0,
+        gravity=9.81,
+        bezier_k1=0.25,
+        bezier_k2=0.75,
+    )
+    profile = compute_steady_phase_profile(params)
+    radii = np.linspace(0.0, params.print_head_radius, 100)
+    heights = profile.height(radii)
+    assert np.all(np.diff(heights) >= -1e-6)
+    assert heights[0] == pytest.approx(0.0)
+    assert heights[-1] > 0.0
+
+
+def test_profile_clamps_outside_radius():
+    params = PrintingParameters(
+        print_head_diameter=5.42,
+        rim_start_height=0.75,
+        contact_angle_deg=45.0,
+        surface_tension=73.0,
+        density=1000.0,
+        gravity=9.81,
+        bezier_k1=0.25,
+        bezier_k2=0.75,
+    )
+    profile = compute_steady_phase_profile(params)
+    heights = profile.height(np.array([params.print_head_radius * 1.5]))
+    assert heights[0] == pytest.approx(0.0)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import trimesh
+
+from convex_slicer.cli import DEFAULT_PARAMS
+from convex_slicer.slicer import ConvexSlicer
+
+
+def test_slicer_generates_expected_number_of_frames(tmp_path: Path):
+    cube = trimesh.creation.box(extents=(1.0, 1.0, 2.0))
+    stl_path = tmp_path / "cube.stl"
+    cube.export(stl_path)
+
+    slicer = ConvexSlicer(DEFAULT_PARAMS, pitch=0.05)
+    output_dir = tmp_path / "frames"
+    result = slicer.slice(stl_path, output_dir)
+
+    assert result.num_frames == 40
+    first_frame = output_dir / "frame_0000.bmp"
+    last_frame = output_dir / "frame_0039.bmp"
+    assert first_frame.exists()
+    assert last_frame.exists()
+
+    metadata_path = output_dir / "metadata.json"
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["pitch"] == pytest.approx(0.05)
+    assert metadata["num_frames"] == 40


### PR DESCRIPTION
## Summary
- add a convex_slicer package that models the steady-state meniscus, voxelises meshes, and exports BMP frame stacks with metadata
- expose a CLI with the default physics parameters and document usage together with gitignore cleanup
- add automated tests for the profile maths and the end-to-end slicing workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca748893448327b021c98bf845c167