### PR TITLE
Implement convex slicing MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # 3D-Slicing
-3D model slicing software that uses convex slicing instead of planar slicing
+
+Convex slicing MVP that loads an STL model, computes a steady phase meniscus and
+produces a stack of bitmap frames aligned to the curved interface.
+
+## Requirements
+
+Install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python main.py path/to/model.stl --output output_directory
+```
+
+Optional arguments allow overriding the physical parameters, pitch and
+in-plane sampling resolution. Generated frames are saved as monochrome BMP
+images named `frame_XXXX.bmp` alongside a `metadata.json` file that captures the
+slicing configuration.

--- a/convex_slicer/__init__.py
+++ b/convex_slicer/__init__.py
@@ -1,0 +1,11 @@
+"""Convex slicing MVP package."""
+
+from .parameters import PrintParameters
+from .meniscus import SteadyPhaseMeniscus
+from .slicer import ConvexSlicer
+
+__all__ = [
+    "PrintParameters",
+    "SteadyPhaseMeniscus",
+    "ConvexSlicer",
+]

--- a/convex_slicer/meniscus.py
+++ b/convex_slicer/meniscus.py
@@ -1,0 +1,103 @@
+"""Steady phase meniscus computation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+from .parameters import PrintParameters
+
+
+@dataclass
+class MeniscusProfile:
+    """Container for the steady phase meniscus data."""
+
+    radius: float
+    control_points: Tuple[float, float, float, float]
+    k1: float
+
+    def height(self, r: np.ndarray) -> np.ndarray:
+        """Evaluate the meniscus height for the supplied radial distances.
+
+        Parameters
+        ----------
+        r:
+            Radial distances in millimetres.
+
+        Returns
+        -------
+        np.ndarray
+            Height values in millimetres with NaN assigned to radii outside the
+            print-head footprint.
+        """
+
+        r = np.asarray(r, dtype=float)
+        t = np.empty_like(r)
+        # Normalise radius and clamp to the valid range
+        with np.errstate(divide="ignore", invalid="ignore"):
+            normalised = r / self.radius
+        np.clip(normalised, 0.0, 1.0, out=normalised)
+        # Apply the k1-controlled easing to redistribute sampling density.
+        exponent = 1.0 / (1.0 + max(self.k1, 1e-6))
+        t[:] = normalised ** exponent
+        b0, b1, b2, b3 = self.control_points
+        omt = 1.0 - t
+        height = (
+            (omt ** 3) * b0
+            + 3.0 * (omt ** 2) * t * b1
+            + 3.0 * omt * (t ** 2) * b2
+            + (t ** 3) * b3
+        )
+        height[r > self.radius] = np.nan
+        return height
+
+    @property
+    def maximum_height(self) -> float:
+        """Return the apex height of the meniscus."""
+
+        return self.control_points[0]
+
+
+class SteadyPhaseMeniscus:
+    """Generate a steady phase meniscus model."""
+
+    def __init__(self, parameters: PrintParameters):
+        self.parameters = parameters
+        self.profile = self._build_profile()
+
+    def _build_profile(self) -> MeniscusProfile:
+        params = self.parameters
+        radius = params.radius
+        theta = params.contact_angle_rad
+        capillary_length = params.capillary_length_mm
+
+        # Primary approximation using a spherical cap constrained by contact angle.
+        sphere_radius = radius / np.sin(theta)
+        cap_height = sphere_radius * (1.0 - np.cos(theta))
+        # Limit the height using the capillary length to avoid unphysical domes.
+        cap_height = float(min(cap_height, 2.0 * capillary_length))
+
+        # Control points for the cubic Bézier representation of the profile.
+        z0 = cap_height
+        z1 = z0  # enforce horizontal tangent at the centre of the meniscus
+
+        # Ideal z2 dictated by the contact angle at the rim
+        target_z2 = (radius * np.tan(theta)) / 3.0
+        # Blend between the spherical cap and the contact-angle constrained value
+        z2 = (1.0 - params.bezier_k2) * z0 + params.bezier_k2 * target_z2
+        z3 = 0.0
+
+        control_points = (z0, z1, z2, z3)
+        return MeniscusProfile(radius=radius, control_points=control_points, k1=params.bezier_k1)
+
+    def height(self, r: np.ndarray) -> np.ndarray:
+        """Convenience wrapper for evaluating the profile."""
+
+        return self.profile.height(r)
+
+    @property
+    def maximum_height(self) -> float:
+        return self.profile.maximum_height
+

--- a/convex_slicer/parameters.py
+++ b/convex_slicer/parameters.py
@@ -1,0 +1,54 @@
+"""Parameter definitions for convex slicing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrintParameters:
+    """Container for the physics and geometry parameters.
+
+    All distances are expressed in millimetres and forces in SI units.
+    """
+
+    print_head_diameter: float
+    rim_start_height: float
+    contact_angle_deg: float
+    surface_tension_mN_m: float
+    density: float
+    gravity: float
+    bezier_k1: float
+    bezier_k2: float
+    pitch: float = 0.05
+
+    @property
+    def radius(self) -> float:
+        """Return the print head radius in millimetres."""
+
+        return self.print_head_diameter / 2.0
+
+    @property
+    def contact_angle_rad(self) -> float:
+        """Contact angle in radians."""
+
+        from math import radians
+
+        return radians(self.contact_angle_deg)
+
+    @property
+    def surface_tension(self) -> float:
+        """Surface tension expressed in N/m."""
+
+        return self.surface_tension_mN_m * 1e-3
+
+    @property
+    def capillary_length_mm(self) -> float:
+        """Capillary length derived from material properties in millimetres."""
+
+        from math import sqrt
+
+        # capillary length computed in metres, then converted to millimetres
+        length_m = sqrt(self.surface_tension / (self.density * self.gravity))
+        return length_m * 1000.0
+

--- a/convex_slicer/slicer.py
+++ b/convex_slicer/slicer.py
@@ -1,0 +1,205 @@
+"""Convex slicing implementation."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import numpy as np
+import trimesh
+from PIL import Image
+
+from .meniscus import SteadyPhaseMeniscus
+from .parameters import PrintParameters
+
+
+@dataclass
+class SliceResult:
+    """Data produced for each generated slice."""
+
+    index: int
+    height: float
+    image_path: Path
+
+
+class ConvexSlicer:
+    """Generate convex slices for a given mesh."""
+
+    def __init__(self, parameters: PrintParameters, pixel_size: float = 0.05):
+        self.parameters = parameters
+        self.pixel_size = pixel_size
+        self.meniscus = SteadyPhaseMeniscus(parameters)
+
+    def slice(self, stl_path: os.PathLike[str] | str, output_dir: os.PathLike[str] | str) -> List[SliceResult]:
+        """Slice the provided STL model using convex slicing.
+
+        Parameters
+        ----------
+        stl_path:
+            Path to the STL mesh.
+        output_dir:
+            Directory where the generated bitmaps and metadata will be stored.
+        """
+
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        mesh = self._load_and_centre_mesh(stl_path)
+        grid_x, grid_y, radius_grid = self._build_xy_grid()
+        meniscus_heights = self.meniscus.height(radius_grid)
+
+        height_map = self._generate_height_map(mesh, grid_x, grid_y)
+        layer_heights = self._build_layer_schedule(mesh)
+
+        results: List[SliceResult] = []
+        for index, base_height in enumerate(layer_heights):
+            surface = base_height + meniscus_heights
+            slice_image = self._create_slice_mask(height_map, surface, meniscus_heights)
+            image_path = output_path / f"frame_{index:04d}.bmp"
+            self._save_bitmap(slice_image, image_path)
+            results.append(SliceResult(index=index, height=float(base_height), image_path=image_path))
+
+        self._write_metadata(results, output_path, mesh)
+        return results
+
+    # ------------------------------------------------------------------
+    # Mesh preparation
+    # ------------------------------------------------------------------
+
+    def _load_and_centre_mesh(self, stl_path: os.PathLike[str] | str) -> trimesh.Trimesh:
+        mesh = trimesh.load_mesh(stl_path)
+        if not isinstance(mesh, trimesh.Trimesh):
+            # In case the file stores a scene we merge the geometries.
+            mesh = trimesh.util.concatenate(mesh.dump())
+        mesh = mesh.copy()
+        mesh.remove_degenerate_faces()
+        mesh.remove_duplicate_faces()
+        mesh.remove_unreferenced_vertices()
+
+        # Centre the model in the XY plane.
+        bounds = mesh.bounds
+        centre_xy = (bounds[0, :2] + bounds[1, :2]) / 2.0
+        mesh.apply_translation(np.array([-centre_xy[0], -centre_xy[1], 0.0]))
+
+        # Raise the model so that the minimum Z matches the rim start height
+        bounds = mesh.bounds
+        z_shift = self.parameters.rim_start_height - bounds[0, 2]
+        mesh.apply_translation([0.0, 0.0, z_shift])
+
+        return mesh
+
+    # ------------------------------------------------------------------
+    # Grid construction
+    # ------------------------------------------------------------------
+
+    def _build_xy_grid(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        radius = self.parameters.radius
+        half_extent = radius
+        spacing = self.pixel_size
+
+        count = max(1, int(math.ceil((2.0 * half_extent) / spacing)))
+        if count % 2 == 0:
+            count += 1
+        coords = (np.arange(count) - count // 2) * spacing
+        grid_x, grid_y = np.meshgrid(coords, coords, indexing="xy")
+        radius_grid = np.sqrt(grid_x ** 2 + grid_y ** 2)
+        return grid_x, grid_y, radius_grid
+
+    # ------------------------------------------------------------------
+    # Height evaluation
+    # ------------------------------------------------------------------
+
+    def _generate_height_map(
+        self, mesh: trimesh.Trimesh, grid_x: np.ndarray, grid_y: np.ndarray
+    ) -> np.ndarray:
+        # Cast vertical rays from above the model to gather the outer surface height.
+        z_top = float(mesh.bounds[1, 2] + 5.0 * self.pixel_size)
+        origins = np.column_stack(
+            [grid_x.reshape(-1), grid_y.reshape(-1), np.full(grid_x.size, z_top)]
+        )
+        directions = np.tile(np.array([0.0, 0.0, -1.0]), (origins.shape[0], 1))
+
+        try:
+            intersector = mesh.ray
+            locations, ray_ids, _ = intersector.intersects_location(origins, directions)
+        except BaseException:
+            from trimesh.ray.ray_triangle import RayMeshIntersector
+
+            intersector = RayMeshIntersector(mesh, exact=False)
+            locations, ray_ids, _ = intersector.intersects_location(origins, directions)
+
+        height_map = np.full(origins.shape[0], -np.inf, dtype=float)
+        for ray_index, z in zip(ray_ids, locations[:, 2]):
+            if z > height_map[ray_index]:
+                height_map[ray_index] = z
+
+        return height_map.reshape(grid_x.shape)
+
+    # ------------------------------------------------------------------
+    # Layer and slicing
+    # ------------------------------------------------------------------
+
+    def _build_layer_schedule(self, mesh: trimesh.Trimesh) -> Iterable[float]:
+        bounds = mesh.bounds
+        model_height = bounds[1, 2] - bounds[0, 2]
+        pitch = self.parameters.pitch
+        num_layers = max(1, int(math.ceil(model_height / pitch)))
+        base = self.parameters.rim_start_height
+        return (base + i * pitch for i in range(num_layers))
+
+    def _create_slice_mask(
+        self,
+        height_map: np.ndarray,
+        surface: np.ndarray,
+        meniscus_heights: np.ndarray,
+    ) -> np.ndarray:
+        mask = height_map >= surface
+        mask = np.where(np.isnan(meniscus_heights), False, mask)
+        return mask.astype(np.uint8) * 255
+
+    def _save_bitmap(self, mask: np.ndarray, path: Path) -> None:
+        image = Image.fromarray(np.flipud(mask.T), mode="L")
+        image.save(path, format="BMP")
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def _write_metadata(
+        self, results: Iterable[SliceResult], output_path: Path, mesh: trimesh.Trimesh
+    ) -> None:
+        metadata = {
+            "parameters": {
+                "print_head_diameter_mm": self.parameters.print_head_diameter,
+                "rim_start_height_mm": self.parameters.rim_start_height,
+                "contact_angle_deg": self.parameters.contact_angle_deg,
+                "surface_tension_mN_m": self.parameters.surface_tension_mN_m,
+                "density": self.parameters.density,
+                "gravity": self.parameters.gravity,
+                "bezier_k1": self.parameters.bezier_k1,
+                "bezier_k2": self.parameters.bezier_k2,
+                "pitch_mm": self.parameters.pitch,
+                "pixel_size_mm": self.pixel_size,
+                "meniscus_apex_height_mm": self.meniscus.maximum_height,
+            },
+            "model": {
+                "bounds_mm": mesh.bounds.tolist(),
+                "height_mm": float(mesh.bounds[1, 2] - mesh.bounds[0, 2]),
+            },
+            "slices": [
+                {
+                    "index": result.index,
+                    "height_mm": result.height,
+                    "image": result.image_path.name,
+                }
+                for result in results
+            ],
+        }
+
+        metadata_path = output_path / "metadata.json"
+        metadata_path.write_text(json.dumps(metadata, indent=2))
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,104 @@
+"""Command line interface for the convex slicing MVP."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from convex_slicer import ConvexSlicer, PrintParameters
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convex slicer MVP")
+    parser.add_argument("stl", type=Path, help="Path to the STL file to slice")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Directory where the generated bitmaps will be written",
+    )
+    parser.add_argument(
+        "--pixel-size",
+        type=float,
+        default=0.05,
+        help="In-plane sampling resolution in millimetres",
+    )
+    parser.add_argument(
+        "--pitch",
+        type=float,
+        default=0.05,
+        help="Vertical pitch between successive slices in millimetres",
+    )
+    parser.add_argument(
+        "--print-head-diameter",
+        type=float,
+        default=5.42,
+        help="Print head diameter in millimetres",
+    )
+    parser.add_argument(
+        "--rim-start-height",
+        type=float,
+        default=0.75,
+        help="Initial rim height relative to the base in millimetres",
+    )
+    parser.add_argument(
+        "--contact-angle",
+        type=float,
+        default=45.0,
+        help="Steady-state contact angle in degrees",
+    )
+    parser.add_argument(
+        "--surface-tension",
+        type=float,
+        default=73.0,
+        help="Surface tension in mN/m",
+    )
+    parser.add_argument(
+        "--density",
+        type=float,
+        default=1000.0,
+        help="Fluid density in kg/m^3",
+    )
+    parser.add_argument(
+        "--gravity",
+        type=float,
+        default=9.81,
+        help="Acceleration due to gravity in m/s^2",
+    )
+    parser.add_argument(
+        "--bezier-k1",
+        type=float,
+        default=0.25,
+        help="First Bézier control weighting",
+    )
+    parser.add_argument(
+        "--bezier-k2",
+        type=float,
+        default=0.75,
+        help="Second Bézier control weighting",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_argument_parser()
+    args = parser.parse_args()
+
+    parameters = PrintParameters(
+        print_head_diameter=args.print_head_diameter,
+        rim_start_height=args.rim_start_height,
+        contact_angle_deg=args.contact_angle,
+        surface_tension_mN_m=args.surface_tension,
+        density=args.density,
+        gravity=args.gravity,
+        bezier_k1=args.bezier_k1,
+        bezier_k2=args.bezier_k2,
+        pitch=args.pitch,
+    )
+
+    slicer = ConvexSlicer(parameters=parameters, pixel_size=args.pixel_size)
+    slicer.slice(args.stl, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+trimesh
+Pillow


### PR DESCRIPTION
## Summary
- add a convex_slicer package that models the steady-phase meniscus and generates slice masks
- provide a command line entry point that centres an STL, applies the steady meniscus and exports BMP frames plus metadata
- document installation requirements and usage for the MVP workflow

## Testing
- pip install -r requirements.txt
- python -m compileall .
- python main.py --help


------
https://chatgpt.com/codex/tasks/task_e_68ca748893448327b021c98bf845c167