### PR TITLE
Use geometric slicing with antialiased rasterization

### DIFF
--- a/convex_slicer/slicer.py
+++ b/convex_slicer/slicer.py
@@ -10,6 +10,9 @@ from typing import Iterable, Optional
 
 import numpy as np
 import trimesh
+from PIL import Image, ImageDraw
+from shapely.geometry import GeometryCollection, LineString, MultiPolygon, Polygon
+from shapely.ops import polygonize, unary_union
 
 from .parameters import PrintingParameters
 from .steady_state import SteadyPhaseProfile, compute_steady_phase_profile
@@ -17,6 +20,8 @@ from .steady_state import SteadyPhaseProfile, compute_steady_phase_profile
 TARGET_WIDTH = 4096
 TARGET_HEIGHT = 2160
 TARGET_MODE = "L"
+SUPERSAMPLE = 2
+
 
 @dataclass
 class SlicingResult:
@@ -26,6 +31,24 @@ class SlicingResult:
     num_frames: int
     pitch: float
     voxel_size: float
+
+
+@dataclass(frozen=True)
+class ProjectionParameters:
+    """Parameters describing the projection of model space onto the image plane."""
+
+    scale: float
+    center_x: float
+    center_y: float
+    supersample: int = SUPERSAMPLE
+
+    @property
+    def canvas_width(self) -> int:
+        return TARGET_WIDTH * self.supersample
+
+    @property
+    def canvas_height(self) -> int:
+        return TARGET_HEIGHT * self.supersample
 
 
 class ConvexSlicer:
@@ -49,25 +72,16 @@ class ConvexSlicer:
 
         mesh = self._load_mesh(stl_path)
         mesh = self._prepare_mesh(mesh)
-        voxel_grid = mesh.voxelized(self.voxel_size).fill()
-        occupancy = voxel_grid.matrix.astype(bool)
-        transform = voxel_grid.transform
-        x_coords, y_coords, z_coords = _axis_coordinates(transform, occupancy.shape)
-
-        xx, yy = np.meshgrid(x_coords, y_coords, indexing="ij", sparse=False)
-        radii = np.sqrt(xx**2 + yy**2)
-        surface_offsets = self.profile.height(radii)
 
         model_height = mesh.bounds[1, 2] - self.params.rim_start_height
-        scale = 1.0
+        meniscus_scale = 1.0
         if self.profile.max_height >= model_height and self.profile.max_height > 0:
-            scale = 0.8 * model_height / self.profile.max_height
-            surface_offsets *= scale
+            meniscus_scale = 0.8 * model_height / self.profile.max_height
 
-        base_surface = self.params.rim_start_height + surface_offsets
-
+        flattened_mesh = _flatten_mesh(mesh, self.profile, meniscus_scale, self.params.rim_start_height)
         num_frames = max(int(math.ceil(model_height / self.pitch)), 1)
-        z_coords = np.asarray(z_coords)
+
+        projection = _compute_projection(mesh)
 
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -78,20 +92,18 @@ class ConvexSlicer:
             "num_frames": num_frames,
             "rim_start_height": self.params.rim_start_height,
             "print_head_radius": self.params.print_head_radius,
-            "meniscus_scale": scale,
+            "meniscus_scale": meniscus_scale,
             "control_points": self.profile.control_points.tolist(),
-
             "image_width": TARGET_WIDTH,
             "image_height": TARGET_HEIGHT,
             "bit_depth": 8,
-
         }
 
         for frame in range(num_frames):
-            lower = base_surface + frame * self.pitch
-            upper = lower + self.pitch
-            slice_mask = _slice_mask(occupancy, z_coords, lower, upper)
-            _save_mask(output_dir, frame, slice_mask)
+            plane_height = frame * self.pitch
+            geometry = _layer_geometry(flattened_mesh, plane_height)
+            image = _rasterize_geometry(geometry, projection)
+            image.save(output_dir / f"frame_{frame:04d}.bmp", format="BMP")
 
         with (output_dir / "metadata.json").open("w", encoding="utf-8") as fp:
             json.dump(metadata, fp, indent=2)
@@ -124,67 +136,168 @@ class ConvexSlicer:
         return mesh
 
 
-def _axis_coordinates(transform: np.ndarray, shape: Iterable[int]) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Compute coordinate arrays for the voxel grid axes."""
+def _flatten_mesh(
+    mesh: trimesh.Trimesh,
+    profile: SteadyPhaseProfile,
+    scale: float,
+    rim_start_height: float,
+) -> trimesh.Trimesh:
+    """Return a copy of ``mesh`` with the meniscus profile flattened."""
 
-    shape = tuple(int(v) for v in shape)
-    origin = transform @ np.array([0.0, 0.0, 0.0, 1.0])
-    axis_vectors = (
-        transform @ np.array([1.0, 0.0, 0.0, 0.0]),
-        transform @ np.array([0.0, 1.0, 0.0, 0.0]),
-        transform @ np.array([0.0, 0.0, 1.0, 0.0]),
+    flattened = mesh.copy()
+    vertices = flattened.vertices.copy()
+    radii = np.linalg.norm(vertices[:, :2], axis=1)
+    offsets = profile.height(radii) * scale + rim_start_height
+    vertices[:, 2] = vertices[:, 2] - offsets
+    flattened.vertices = vertices
+    return flattened
+
+
+def _compute_projection(mesh: trimesh.Trimesh) -> ProjectionParameters:
+    """Compute projection parameters to map model coordinates to pixels."""
+
+    bounds = mesh.bounds
+    width = max(bounds[1, 0] - bounds[0, 0], 1e-6)
+    height = max(bounds[1, 1] - bounds[0, 1], 1e-6)
+    center_x = (bounds[0, 0] + bounds[1, 0]) / 2.0
+    center_y = (bounds[0, 1] + bounds[1, 1]) / 2.0
+
+    scale_x = (TARGET_WIDTH * SUPERSAMPLE) / width
+    scale_y = (TARGET_HEIGHT * SUPERSAMPLE) / height
+    scale = min(scale_x, scale_y)
+
+    return ProjectionParameters(scale=scale, center_x=center_x, center_y=center_y)
+
+
+def _layer_geometry(mesh: trimesh.Trimesh, plane_height: float):
+    """Intersect ``mesh`` with a horizontal plane at ``plane_height``."""
+
+    if mesh.is_empty:
+        return None
+
+    section = mesh.section(
+        plane_origin=[0.0, 0.0, plane_height],
+        plane_normal=[0.0, 0.0, 1.0],
     )
-    x_coords = origin[0] + axis_vectors[0][0] * np.arange(shape[0])
-    y_coords = origin[1] + axis_vectors[1][1] * np.arange(shape[1])
-    z_coords = origin[2] + axis_vectors[2][2] * np.arange(shape[2])
-    return x_coords, y_coords, z_coords
+    if section is None or not section.entities:
+        return None
+
+    lines: list[LineString] = []
+    for coords in section.discrete:
+        if len(coords) < 3:
+            continue
+        xy = coords[:, :2]
+        line = LineString(xy)
+        if line.length > 0:
+            lines.append(line)
+
+    if not lines:
+        return None
+
+    raw_polygons = [poly for poly in polygonize(lines) if poly.area > 0.0]
+    cleaned_polygons: list[Polygon] = []
+    for poly in raw_polygons:
+        if not poly.is_valid:
+            poly = poly.buffer(0)
+        if poly.area <= 1e-10:
+            continue
+        cleaned_polygons.append(poly)
+
+    if not cleaned_polygons:
+        return None
+
+    parents = [None] * len(cleaned_polygons)
+    areas = [poly.area for poly in cleaned_polygons]
+    for i, poly_i in enumerate(cleaned_polygons):
+        parent_index = None
+        parent_area = float("inf")
+        for j, poly_j in enumerate(cleaned_polygons):
+            if i == j:
+                continue
+            if areas[j] <= areas[i]:
+                continue
+            if poly_j.contains(poly_i) and areas[j] < parent_area:
+                parent_index = j
+                parent_area = areas[j]
+        parents[i] = parent_index
+
+    children: dict[int, list[int]] = {i: [] for i in range(len(cleaned_polygons))}
+    for child, parent in enumerate(parents):
+        if parent is not None:
+            children[parent].append(child)
+
+    depths = [0] * len(cleaned_polygons)
+    for i in range(len(cleaned_polygons)):
+        depth = 0
+        parent = parents[i]
+        while parent is not None:
+            depth += 1
+            parent = parents[parent]
+        depths[i] = depth
+
+    positive_regions = []
+    for i, polygon in enumerate(cleaned_polygons):
+        if depths[i] % 2 != 0:
+            continue
+        hole_indices = [child for child in children[i] if depths[child] == depths[i] + 1]
+        if hole_indices:
+            holes = unary_union([cleaned_polygons[h] for h in hole_indices])
+            polygon = polygon.difference(holes)
+        if not polygon.is_empty:
+            positive_regions.append(polygon)
+
+    if not positive_regions:
+        return None
+
+    return unary_union(positive_regions)
 
 
-def _slice_mask(
-    occupancy: np.ndarray,
-    z_coords: np.ndarray,
-    lower: np.ndarray,
-    upper: np.ndarray,
-) -> np.ndarray:
-    """Compute a binary mask for a slice between ``lower`` and ``upper`` surfaces."""
+def _rasterize_geometry(geometry, projection: ProjectionParameters) -> Image.Image:
+    """Rasterise the layer geometry onto the supersampled canvas."""
 
-    z_grid = z_coords[np.newaxis, np.newaxis, :]
-    within = (z_grid >= lower[..., np.newaxis]) & (z_grid < upper[..., np.newaxis])
-    hits = occupancy & within
-    mask = np.any(hits, axis=2)
-    return mask
+    canvas = Image.new(TARGET_MODE, (projection.canvas_width, projection.canvas_height), color=0)
+    if geometry is None or geometry.is_empty:
+        return canvas.resize((TARGET_WIDTH, TARGET_HEIGHT), resample=Image.LANCZOS)
 
+    draw = ImageDraw.Draw(canvas)
 
-def _save_mask(output_dir: Path, index: int, mask: np.ndarray) -> None:
-    """Write the mask as an 8-bit BMP image with 4K DCI resolution."""
+    for polygon in _iter_polygons(geometry):
+        exterior = _project_ring(polygon.exterior.coords, projection)
+        if len(exterior) >= 3:
+            draw.polygon(exterior, fill=255)
+        for interior in polygon.interiors:
+            hole = _project_ring(interior.coords, projection)
+            if len(hole) >= 3:
+                draw.polygon(hole, fill=0)
 
-    frame = _render_frame(mask)
-    frame.save(output_dir / f"frame_{index:04d}.bmp", format="BMP")
-
-
-def _render_frame(mask: np.ndarray) -> "Image.Image":
-    """Project the boolean mask onto the 4K target canvas."""
-    """Write the mask as an 8-bit BMP image."""
-
-    from PIL import Image
-
-    array = (mask.astype(np.uint8) * 255).T[::-1, :]
-    base_image = Image.fromarray(array).convert(TARGET_MODE)
-    if base_image.size == (TARGET_WIDTH, TARGET_HEIGHT):
-        return base_image
-
-    width_scale = TARGET_WIDTH / base_image.width if base_image.width else 1.0
-    height_scale = TARGET_HEIGHT / base_image.height if base_image.height else 1.0
-    scale = min(width_scale, height_scale)
-    scaled_width = max(1, min(TARGET_WIDTH, int(round(base_image.width * scale))))
-    scaled_height = max(1, min(TARGET_HEIGHT, int(round(base_image.height * scale))))
-
-    resized = base_image.resize((scaled_width, scaled_height), resample=Image.NEAREST)
-    canvas = Image.new(TARGET_MODE, (TARGET_WIDTH, TARGET_HEIGHT), color=0)
-    left = (TARGET_WIDTH - scaled_width) // 2
-    top = (TARGET_HEIGHT - scaled_height) // 2
-    canvas.paste(resized, (left, top))
+    if projection.supersample > 1:
+        canvas = canvas.resize((TARGET_WIDTH, TARGET_HEIGHT), resample=Image.LANCZOS)
     return canvas
 
-    image = Image.fromarray(array)
-    image.save(output_dir / f"frame_{index:04d}.bmp")
+
+def _project_ring(coords: Iterable[tuple[float, float]], projection: ProjectionParameters) -> list[tuple[float, float]]:
+    """Project planar coordinates to pixel coordinates."""
+
+    coords_array = np.asarray(coords, dtype=float)
+    if coords_array.ndim != 2 or coords_array.shape[1] != 2:
+        return []
+    x = (coords_array[:, 0] - projection.center_x) * projection.scale + projection.canvas_width / 2.0
+    y = (projection.center_y - coords_array[:, 1]) * projection.scale + projection.canvas_height / 2.0
+    return [(float(px), float(py)) for px, py in zip(x, y)]
+
+
+def _iter_polygons(geometry) -> Iterable[Polygon]:
+    """Yield polygons from an arbitrary Shapely geometry."""
+
+    if geometry.is_empty:
+        return []
+    if isinstance(geometry, Polygon):
+        return [geometry]
+    if isinstance(geometry, MultiPolygon):
+        return [poly for poly in geometry.geoms if not poly.is_empty]
+    if isinstance(geometry, GeometryCollection):
+        polygons: list[Polygon] = []
+        for geom in geometry.geoms:
+            polygons.extend(_iter_polygons(geom))
+        return polygons
+    return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ trimesh
 Pillow
 scipy
 pytest
+shapely
+networkx


### PR DESCRIPTION
## Summary
- replace the voxel-grid mask with geometric plane intersections to compute each slice
- flatten the mesh by the meniscus profile and supersample rasterisation for smooth BMP output
- add shapely and networkx dependencies for polygon handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb5d0a1c9c832783582e7c03fbb7b4