### PR TITLE
Implement geometric polygon-based slicing pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ numpy
 trimesh
 Pillow
 scipy
+shapely
+networkx
 pytest


### PR DESCRIPTION
## Summary
- replace voxel-grid slicing with geometric polygon extraction and anti-aliased rasterisation
- warp the mesh by the meniscus profile so radial surface offsets become planar slice heights
- add helpers for planar transforms and polygon rasterisation, and include shapely/networkx dependencies

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb5d0a1c9c832783582e7c03fbb7b4