### PR TITLE
Implement geometric convex slicing with antialiased rasterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 - Computes a steady-phase convex meniscus using the supplied physics parameters
   (surface tension, density, gravity, print-head geometry, Bézier control
   coefficients).
-- Voxelises the mesh and generates a sequence of BMP frames that follow the
-  curved meniscus for each pitch increment.
+- Intersects the mesh geometry with each convex slicing plane to obtain
+  high-fidelity polygonal cross-sections and rasterises them with
+  anti-aliasing at 4K resolution.
   
 - Writes metadata describing the slicing run (pitch, voxel size, meniscus
   control points and scaling).
@@ -28,7 +29,8 @@ python -m convex_slicer.cli path/to/model.stl output_directory --pitch 0.05
 
 Optional arguments:
 
-- `--voxel-size`: specify a custom voxel size (defaults to the pitch).
+- `--voxel-size`: legacy argument retained for compatibility; geometric
+  slicing no longer uses an intermediate voxel grid.
 - `--params`: path to a JSON file overriding the default material and geometry
   parameters.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ numpy
 trimesh
 Pillow
 scipy
+shapely
+networkx
 pytest


### PR DESCRIPTION
## Summary
- replace the voxel grid workflow with geometric cross-sections to avoid stair-stepping artefacts
- rasterise slice polygons onto the 4K canvas with supersampling for smooth edges
- document the new pipeline and add shapely/networkx dependencies needed for polygon extraction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb5d0a1c9c832783582e7c03fbb7b4