### PR TITLE
Add gradient color output for slicer frames

### DIFF
--- a/convex_slicer/slicer.py
+++ b/convex_slicer/slicer.py
@@ -16,7 +16,7 @@ from .steady_state import SteadyPhaseProfile, compute_steady_phase_profile
 
 TARGET_WIDTH = 4096
 TARGET_HEIGHT = 2160
-TARGET_MODE = "L"
+TARGET_MODE = "RGB"
 
 @dataclass
 class SlicingResult:
@@ -84,14 +84,25 @@ class ConvexSlicer:
             "image_width": TARGET_WIDTH,
             "image_height": TARGET_HEIGHT,
             "bit_depth": 8,
+            "color_mode": TARGET_MODE,
 
         }
+
+        min_height = float(self.params.rim_start_height)
+        max_height = float(self.params.rim_start_height + model_height)
 
         for frame in range(num_frames):
             lower = base_surface + frame * self.pitch
             upper = lower + self.pitch
-            slice_mask = _slice_mask(occupancy, z_coords, lower, upper)
-            _save_mask(output_dir, frame, slice_mask)
+            mask, height_map = _slice_height_map(occupancy, z_coords, lower, upper)
+            _save_frame(
+                output_dir,
+                frame,
+                mask,
+                height_map,
+                min_height=min_height,
+                max_height=max_height,
+            )
 
         with (output_dir / "metadata.json").open("w", encoding="utf-8") as fp:
             json.dump(metadata, fp, indent=2)
@@ -140,36 +151,66 @@ def _axis_coordinates(transform: np.ndarray, shape: Iterable[int]) -> tuple[np.n
     return x_coords, y_coords, z_coords
 
 
-def _slice_mask(
+def _slice_height_map(
     occupancy: np.ndarray,
     z_coords: np.ndarray,
     lower: np.ndarray,
     upper: np.ndarray,
-) -> np.ndarray:
-    """Compute a binary mask for a slice between ``lower`` and ``upper`` surfaces."""
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute a mask and height map for a slice between ``lower`` and ``upper`` surfaces."""
 
     z_grid = z_coords[np.newaxis, np.newaxis, :]
     within = (z_grid >= lower[..., np.newaxis]) & (z_grid < upper[..., np.newaxis])
     hits = occupancy & within
-    mask = np.any(hits, axis=2)
-    return mask
+    if not np.any(hits):
+        mask = np.zeros(lower.shape, dtype=bool)
+        heights = np.zeros(lower.shape, dtype=float)
+        return mask, heights
+
+    height_candidates = np.where(hits, z_grid, -np.inf)
+    heights = height_candidates.max(axis=2)
+    mask = np.isfinite(heights)
+    heights[~mask] = 0.0
+    return mask, heights
 
 
-def _save_mask(output_dir: Path, index: int, mask: np.ndarray) -> None:
-    """Write the mask as an 8-bit BMP image with 4K DCI resolution."""
+def _save_frame(
+    output_dir: Path,
+    index: int,
+    mask: np.ndarray,
+    heights: np.ndarray,
+    *,
+    min_height: float,
+    max_height: float,
+) -> None:
+    """Write the height map as an RGB BMP image with 4K DCI resolution."""
 
-    frame = _render_frame(mask)
+    frame = _render_frame(mask, heights, min_height=min_height, max_height=max_height)
     frame.save(output_dir / f"frame_{index:04d}.bmp", format="BMP")
 
 
-def _render_frame(mask: np.ndarray) -> "Image.Image":
-    """Project the boolean mask onto the 4K target canvas."""
-    """Write the mask as an 8-bit BMP image."""
+def _render_frame(
+    mask: np.ndarray,
+    heights: np.ndarray,
+    *,
+    min_height: float,
+    max_height: float,
+) -> "Image.Image":
+    """Project the height map onto the 4K target canvas using a color gradient."""
 
     from PIL import Image
 
-    array = (mask.astype(np.uint8) * 255).T[::-1, :]
-    base_image = Image.fromarray(array).convert(TARGET_MODE)
+    valid = mask.astype(bool)
+    dynamic_range = max(max_height - min_height, 1e-9)
+    normalized = np.zeros_like(heights, dtype=float)
+    normalized[valid] = (heights[valid] - min_height) / dynamic_range
+    normalized = np.clip(normalized, 0.0, 1.0)
+
+    colorized = _apply_colormap(normalized)
+    colorized[~valid] = 0
+
+    array = colorized.transpose(1, 0, 2)[::-1, :, :]
+    base_image = Image.fromarray(array)
     if base_image.size == (TARGET_WIDTH, TARGET_HEIGHT):
         return base_image
 
@@ -179,12 +220,34 @@ def _render_frame(mask: np.ndarray) -> "Image.Image":
     scaled_width = max(1, min(TARGET_WIDTH, int(round(base_image.width * scale))))
     scaled_height = max(1, min(TARGET_HEIGHT, int(round(base_image.height * scale))))
 
-    resized = base_image.resize((scaled_width, scaled_height), resample=Image.NEAREST)
-    canvas = Image.new(TARGET_MODE, (TARGET_WIDTH, TARGET_HEIGHT), color=0)
+    resized = base_image.resize((scaled_width, scaled_height), resample=Image.BILINEAR)
+    canvas = Image.new(TARGET_MODE, (TARGET_WIDTH, TARGET_HEIGHT), color=(0, 0, 0))
     left = (TARGET_WIDTH - scaled_width) // 2
     top = (TARGET_HEIGHT - scaled_height) // 2
     canvas.paste(resized, (left, top))
     return canvas
 
-    image = Image.fromarray(array)
-    image.save(output_dir / f"frame_{index:04d}.bmp")
+def _apply_colormap(normalized: np.ndarray) -> np.ndarray:
+    """Map normalized values in [0, 1] to an RGB gradient."""
+
+    colormap = np.array(
+        [
+            [0.267004, 0.004874, 0.329415],
+            [0.282327, 0.094955, 0.417331],
+            [0.253935, 0.265254, 0.529983],
+            [0.163625, 0.471133, 0.558148],
+            [0.134692, 0.658636, 0.517649],
+            [0.477504, 0.821444, 0.318195],
+            [0.993248, 0.906157, 0.143936],
+        ]
+    )
+    positions = np.linspace(0.0, 1.0, colormap.shape[0])
+
+    flat = normalized.reshape(-1)
+    red = np.interp(flat, positions, colormap[:, 0])
+    green = np.interp(flat, positions, colormap[:, 1])
+    blue = np.interp(flat, positions, colormap[:, 2])
+
+    rgb = np.stack([red, green, blue], axis=1)
+    rgb = (np.clip(rgb, 0.0, 1.0) * 255.0 + 0.5).astype(np.uint8)
+    return rgb.reshape(normalized.shape + (3,))


### PR DESCRIPTION
## Summary
- render slice frames using a viridis-inspired gradient derived from height data instead of binary masks
- propagate color metadata and update image scaling to keep the RGB output centered on the 4K canvas
- extend the slicer test to validate RGB frames, non-zero color content, and recorded color mode metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb674f05d08327b62327345d15af79