### PR TITLE
Configure slicer output for 1-bit 4K frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ python -m convex_slicer.cli path/to/model.stl output_directory --pitch 0.05
 
 Optional arguments:
 
-- `--voxel-size`: specify a custom voxel size (defaults to the pitch).
+- `--voxel-size`: specify a custom voxel size in millimetres (defaults to 0.01 mm).
 - `--params`: path to a JSON file overriding the default material and geometry
   parameters.
 
-Each frame is written as an 8-bit monochrome BMP named `frame_XXXX.bmp`. The
+Each frame is written as a 1-bit monochrome 4K BMP named `frame_XXXX.bmp`. The
 `slicing/metadata.json` file captures the parameters used for the run.
 
 ## Default parameters

--- a/convex_slicer/cli.py
+++ b/convex_slicer/cli.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 
 from .parameters import PrintingParameters
-from .slicer import ConvexSlicer
+from .slicer import ConvexSlicer, DEFAULT_VOXEL_SIZE
 
 
 DEFAULT_PARAMS = PrintingParameters(
@@ -39,8 +39,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--voxel-size",
         type=float,
-        default=None,
-        help="Override the voxel size used for rasterisation (default: pitch)",
+        default=DEFAULT_VOXEL_SIZE,
+        help=(
+            "Override the voxel size used for rasterisation in millimetres "
+            f"(default: {DEFAULT_VOXEL_SIZE})"
+        ),
     )
     parser.add_argument(
         "--params",

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -30,7 +30,7 @@ def test_slicer_generates_expected_number_of_frames(tmp_path: Path):
 
     with Image.open(first_frame) as frame:
         assert frame.size == (4096, 2160)
-        assert frame.mode == "L"
+        assert frame.mode == "1"
 
 
     metadata_path = output_dir / "metadata.json"
@@ -40,4 +40,5 @@ def test_slicer_generates_expected_number_of_frames(tmp_path: Path):
     assert metadata["num_frames"] == 40
     assert metadata["image_width"] == 4096
     assert metadata["image_height"] == 2160
-    assert metadata["bit_depth"] == 8
+    assert metadata["bit_depth"] == 1
+    assert metadata["pixels_per_mm"] == pytest.approx(50)


### PR DESCRIPTION
## Summary
- update the CLI to default to a 0.01 mm voxel size while keeping it configurable
- render frames as 1-bit 4K BMPs scaled at 50 px/mm and adjust slicing metadata accordingly
- refresh documentation and tests to reflect the new output format and metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e70daf8a288327bcf7d689e9ecf05a